### PR TITLE
fix: Pin semantic-release to version 22

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,4 +32,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.SEMANTIC_RELEASE_GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.SEMANTIC_RELEASE_NPM_TOKEN }}
-        run: npx semantic-release
+        run: npx semantic-release@22


### PR DESCRIPTION
### Summary

Resolves release issue by pinning `semantic-release` to version 22

Error -> https://github.com/openedx/frontend-component-ai-translations/actions/runs/7613100264/job/20732212206